### PR TITLE
Don't crash application if newrelic ext is missing

### DIFF
--- a/Newrelic.php
+++ b/Newrelic.php
@@ -70,10 +70,15 @@ class Newrelic extends Component implements BootstrapInterface
     {
         parent::init();
 
-        if ($this->enabled && Agent::isLoaded()) {
-            $this->name = $this->name ? $this->name : \Yii::$app->name;
-            $this->agent = new Agent();
-            $this->agent->setAppname($this->name, $this->licence);
+        if ($this->enabled) {
+            if (Agent::isLoaded()) {
+                $this->name = $this->name ? $this->name : \Yii::$app->name;
+                $this->agent = new Agent();
+                $this->agent->setAppname($this->name, $this->licence);
+            } else {
+                $this->enabled = false;
+                \Yii::$app->getLog()->getLogger()->log('Newrelic extension is not loaded', \yii\log\Logger::LEVEL_ERROR);
+            }
         }
     }
 }


### PR DESCRIPTION
I think this extension shouldn't crash all the appliation if something went wrong with 'newrelic' php extension.
What is going on now if 'newrelic' is suddenly missing:
All the application fails with
`PHP Fatal Error – yii\base\ErrorException
Call to a member function startTransaction() on null`
This tells nothing to me about what's actually happened. So I make extension to disable itself when no 'newrelic' was loaded and write error message in log
