### PR TITLE
use extension key by default

### DIFF
--- a/Newrelic.php
+++ b/Newrelic.php
@@ -32,7 +32,7 @@ class Newrelic extends Component implements BootstrapInterface
     /**
      * @var string Licence key
      */
-    public $licence = 'newrelic.license';
+    public $licence = null; // use extension key by default
 
     /**
      * @var string handlers\Handler


### PR DESCRIPTION
if license is not stated implicitly in the config the Agent will use default newrelic license from php.ini