### PR TITLE
chore: Remove preg_replace and just get raw JS

### DIFF
--- a/handlers/WebHandler.php
+++ b/handlers/WebHandler.php
@@ -16,21 +16,13 @@ class WebHandler extends BaseHandler
                 Application::EVENT_BEFORE_ACTION,
                 function () use ($app, &$agent) {
                     $app->controller->view->registerJs(
-                        preg_replace(
-                            '#</?script( type="text/javascript")?>#',
-                            '',
-                            $this->getAgent()->getBrowserTimingHeader()
-                        ),
+                        $this->getAgent()->getBrowserTimingHeader(false),
                         View::POS_HEAD,
                         'newrelic-head'
                     );
 
                     $app->controller->view->registerJs(
-                        preg_replace(
-                            '#</?script( type="text/javascript")?>#',
-                            '',
-                            $this->getAgent()->getBrowserTimingFooter()
-                        ),
+                        $this->getAgent()->getBrowserTimingFooter(false),
                         View::POS_END,
                         'newrelic-end'
                     );


### PR DESCRIPTION
By passing `false` to `getBrowserTimingHeader` and `getBrowserTimingFooter`, you can just get the raw javascript returned.

- [SobanVuex\NewRelic source](https://github.com/sobanvuex/php-newrelic/blob/e0b1d22f2d305b5230473288933fb455cb64f6bd/src/Agent.php#L287-L294)
- [NewRelic docs](https://docs.newrelic.com/docs/apm/agents/php-agent/php-agent-api/newrelic_get_browser_timing_header/)
